### PR TITLE
Use PYPI_TEST_TOKEN for TestPyPI (fixes #38)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,5 +53,5 @@ jobs:
       - name: Upload to PyPI or TestPyPI
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ inputs.environment == 'pypi' && secrets.PYPI_TOKEN || secrets.TEST_PYPI_TOKEN }}
+          TWINE_PASSWORD: ${{ inputs.environment == 'pypi' && secrets.PYPI_TOKEN || secrets.PYPI_TEST_TOKEN }}
         run: twine upload --verbose --repository ${{ inputs.environment }} wheelhouse/*.whl


### PR DESCRIPTION
Fixes #38.

Updates the release workflow to use `secrets.PYPI_TEST_TOKEN` instead of `secrets.TEST_PYPI_TOKEN` so TestPyPI uploads use the correct secret name.