### PR TITLE
Clarify docs: GNUBG Neural Networks is the library, not the full game (fixes #40)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -11,5 +11,5 @@
 # lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
 # polar: # Replace with a single Polar username
 # buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
-thanks_dev: u/gh/reayd-falmouth
+thanks_dev: u/gh/StonesAndDice
 # custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -22,4 +22,4 @@ jobs:
           # 1. \d+- allows "123-somename" (GitHub default) and "1-WORDS"
           # 2. (feature|fix|...)\/ allows "feature/somename", "fix/1-WORDS"
           # 3. [a-zA-Z0-9\-_]+ allows uppercase in names (e.g. WORDS)
-          regex: '^((feature|bugfix|hotfix|test|fix)\/|\d+-)[a-zA-Z0-9\-_]+$'
+          regex: '^((feature|bugfix|hotfix|test|fix|docs)\/|\d+-)[a-zA-Z0-9\-_]+$'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/gnubg-nn"]
 	path = src/gnubg-nn
-	url = git@github.com:reayd-falmouth/gnubg-nn.git
+	url = git@github.com:StonesAndDice/gnubg-nn.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,23 +2,25 @@ Contributing Guide for gnubg-nn-pypi
 ====================================
 
 Thank you for considering contributing to gnubg-nn-pypi, the Python bindings
-for the GNUBG neural-network evaluation engine.
+for the **GNUBG neural-network evaluation library**. This package is the neural
+network library (position analysis, cube decisions, rollouts) — not the full
+GNU Backgammon application (GUI, match play).
 
-This project integrates with the upstream GNUBG C/C++ engine, maintained
+This project integrates with the upstream GNUBG C/C++ code, maintained
 separately by the GNU Backgammon team.
 
 You can contribute to either:
 
-1. **The GNUBG Project (C/C++ Core)**
-2. **The gnubg-nn-pypi Project (Python Bindings)**
+1. **The full GNUBG project (C/C++ application and core)**
+2. **The gnubg-nn-pypi project (Python bindings to the neural network library)**
 
 Please read the relevant section(s) below based on your area of interest.
 
 -----------------------------------------
-1. Contributing to the GNUBG Core Project
+1. Contributing to the full GNUBG project
 -----------------------------------------
 
-The upstream GNUBG engine is maintained at:
+The upstream GNU Backgammon application and engine are maintained at:
 - Source: https://git.savannah.gnu.org/cgit/gnubg/gnubg.git
 - Contributor registration: https://savannah.gnu.org/people/
 
@@ -34,14 +36,14 @@ or C/C++ code:
 2. Contributing to gnubg-nn-pypi (Python API)
 ---------------------------------------------
 
-The `gnubg-nn-pypi` project exposes core GNUBG functionality to Python.
+The `gnubg-nn-pypi` project exposes the GNUBG neural network evaluation library to Python.
 
-GitHub Repo: https://github.com/reayd-falmouth/gnubg-nn-pypi
+GitHub Repo: https://github.com/StonesAndDice/gnubg-nn-pypi
 
 You can contribute by:
 
 - **Reporting Bugs:**  
-  File an issue at https://github.com/reayd-falmouth/gnubg-nn-pypi/issues
+  File an issue at https://github.com/StonesAndDice/gnubg-nn-pypi/issues
 
 - **Writing Code:**
     - Fork the repository and create a feature branch.
@@ -50,7 +52,7 @@ You can contribute by:
     - Submit a pull request with a clear explanation of your change.
 
 - **Testing & Validation:**
-    - Run: `python3 -m unittest discover -s gnubg.tests`
+    - Run: `python3 -m unittest discover -s gnubg_nn.tests`
     - Add new unit tests if you're introducing new features.
 
 - **Improving Documentation:**
@@ -75,7 +77,7 @@ Need Help?
 ---------------------
 
 Please reach out via:
-- GitHub Issues: https://github.com/reayd-falmouth/gnubg-nn-pypi/issues
+- GitHub Issues: https://github.com/StonesAndDice/gnubg-nn-pypi/issues
 - Mailing List: https://lists.gnu.org/mailman/listinfo/gnubg
 
-Thank you for contributing to the GNUBG community!
+Thank you for contributing to the GNUBG neural network library and the broader GNUBG community!

--- a/README.md
+++ b/README.md
@@ -1,41 +1,41 @@
 <h1 align="center">
-<img src="https://raw.githubusercontent.com/reayd-falmouth/gnubg-nn-pypi/refs/heads/main/img/banner.png">
+<img src="https://raw.githubusercontent.com/StonesAndDice/gnubg-nn-pypi/refs/heads/main/img/banner.png">
 
-GNUBG
+GNUBG Neural Networks
 </h1>
 
 [![PyPI Downloads](https://img.shields.io/pypi/dm/gnubg-nn-pypi.svg?label=PyPI%20downloads)](https://pypi.org/project/gnubg-nn-pypi/)
 [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gnubg-nn-pypi.svg?label=Conda%20downloads)](https://anaconda.org/conda-forge/gnubg-nn-pypi/)
-[![GitHub issues](https://img.shields.io/github/issues/gnubg/gnubg-nn-pypi.svg)](https://github.com/reayd-falmouth/gnubg-nn-pypi/issues)
+[![GitHub issues](https://img.shields.io/github/issues/gnubg/gnubg-nn-pypi.svg)](https://github.com/StonesAndDice/gnubg-nn-pypi/issues)
 [![License](https://img.shields.io/badge/license-GPL%20v2-blue.svg)](#license)
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-Ask%20questions-blue.svg)](https://stackoverflow.com/questions/tagged/gnubg)
 
-GNUBG NeuralNet Python bindings bring the powerful GNUBG backgammon neural-network engine to Python 3.
+**GNUBG Neural Networks** (this package, `gnubg-nn`) is a *library* that provides Python bindings to the GNUBG neural-network evaluation engine — the same engine used for position analysis and cube decisions in the full [GNU Backgammon](https://www.gnu.org/software/gnubg/) application, but packaged as a standalone library for use in scripts, analysis tools, and applications. It is not the full backgammon game (GUI, match play, etc.).
 
 ## Quick Start
 
-`gnubg` is a native Python extension module that wraps the GNU Backgammon neural-net evaluation engine, so you can call 
-the same position-analysis and cube-decision routines that power the GUI from any Python 3.8–3.13 script or application. It’s ideal for batch processing, data-science workflows, or building custom tools and UIs.
+`gnubg_nn` is a native Python extension module that wraps the GNUBG neural-net evaluation library, so you can call 
+the same position-analysis and cube-decision routines that power the full GNU Backgammon application from any Python 3.10+ script or application. It’s ideal for batch processing, data-science workflows, or building custom tools and UIs.
 
 ### Installation
 
 ```bash
-pip install gnubg
+pip install gnubg-nn
 ````
 
 ### Getting Started
 
 ```python
-import gnubg
+import gnubg_nn
 
 # Load the engine (weights, bear-off tables, etc. are initialized)
-gnubg.initnet()
+gnubg_nn.initnet()
 
 # Convert a position key (20-char A–Z or 14-char Base64) to a board
-board = gnubg.boardfromkey("4HPwATDgc/ABMA")
+board = gnubg_nn.boardfromkey("4HPwATDgc/ABMA")
 
 # Evaluate win/gammon/backgammon probabilities and equity at 4 plies
-win, gamm, bg, equity = gnubg.probabilities(board, 4)
+win, gamm, bg, equity = gnubg_nn.probabilities(board, 4)
 
 print(f"Win: {win:.3f}, Gammon: {gamm:.3f}, Backgammon: {bg:.3f}, Equity: {equity:.3f}")
 ```
@@ -44,11 +44,11 @@ That’s all you need to get up and running! For detailed API docs, advanced bui
 sections below or visit the full documentation on [ReadTheDocs](https://gnubg.readthedocs.io/en/latest/).
 
 * **ReadTheDocs** [https://gnubg.readthedocs.io/en/latest/](https://gnubg.readthedocs.io/en/latest/)
-* **Website:** [https://www.gnu.org/software/gnubg/](https://www.gnu.org/software/gnubg/)
+* **GNU Backgammon (full application):** [https://www.gnu.org/software/gnubg/](https://www.gnu.org/software/gnubg/)
 * **Original Documentation:** [http://www.gnubg.org/documentation/doku.php?id=gnu_backgammon_faq](http://www.gnubg.org/documentation/doku.php?id=gnu_backgammon_faq)
 * **Mailing list:** [https://lists.gnu.org/mailman/listinfo/gnubg](https://lists.gnu.org/mailman/listinfo/gnubg)
-* **Source code:** [https://github.com/reayd-falmouth/gnubg-nn-pypi](https://github.com/reayd-falmouth/gnubg-nn-pypi)
-* **GNUBG Project:** [https://git.savannah.gnu.org/cgit/gnubg/gnubg-nn.git](https://git.savannah.gnu.org/cgit/gnubg/gnubg-nn.git)
+* **Source code:** [https://github.com/StonesAndDice/gnubg-nn-pypi](https://github.com/StonesAndDice/gnubg-nn-pypi)
+* **GNUBG Neural Networks (gnubg-nn) upstream:** [https://git.savannah.gnu.org/cgit/gnubg/gnubg-nn.git](https://git.savannah.gnu.org/cgit/gnubg/gnubg-nn.git)
 * **Contributing:** [https://savannah.gnu.org/people/](https://savannah.gnu.org/people/)
 * **Credits:** [https://git.savannah.gnu.org/cgit/gnubg.git/tree/credits.sh](https://git.savannah.gnu.org/cgit/gnubg.git/tree/credits.sh)
 
@@ -85,7 +85,7 @@ It provides:
 gnubg-nn-pypi has some basic unit testing. After installation, run:
 
 ```bash
-python3 -m unittest discover -s gnubg.tests
+python3 -m unittest discover -s gnubg_nn.tests
 ```
 ## AI-Assisted Development
 
@@ -103,7 +103,7 @@ These models were used to assist with code generation, documentation drafting, a
 
 ## Code of Conduct
 
-Please read the [Code of Conduct](https://github.com/reayd-falmouth/gnubg-nn-pypi/blob/main/CONDUCT.md) to learn how to interact positively.
+Please read the [Code of Conduct](https://github.com/StonesAndDice/gnubg-nn-pypi/blob/main/CONDUCT.md) to learn how to interact positively.
 
 ## Contributing
 
@@ -118,17 +118,17 @@ Your expertise and enthusiasm are welcome! You can contribute by:
 * Assisting with outreach and onboarding
 * Writing grant proposals or helping with fundraising
 
-For more information, see our [Contributing Guide](https://github.com/reayd-falmouth/gnubg-nn-pypi/blob/main/CONTRIBUTING.md). If you’re unsure where to start, open an issue or join the discussion on our mailing list!
+For more information, see our [Contributing Guide](https://github.com/StonesAndDice/gnubg-nn-pypi/blob/main/CONTRIBUTING.md). If you’re unsure where to start, open an issue or join the discussion on our mailing list!
 
 ## Acknowledgments
 
-This project builds upon the extensive work of the GNU Backgammon (GNUBG) community. Specifically the 
+This project builds upon the extensive work of the GNU Backgammon (GNUBG) community. The *gnubg-nn* library is the neural network evaluation component; the full backgammon application (GUI, match play, etc.) is maintained separately. We specifically acknowledge the 
 [pygnubg](https://git.savannah.gnu.org/cgit/gnubg/gnubg-nn.git/tree/py) program developed by Joseph Heled.
 
-We express our gratitude to all contributors who have dedicated their time and expertise to the development of GNUBG.
+We express our gratitude to all contributors who have dedicated their time and expertise to the development of the GNUBG neural network library and its Python bindings.
 
-- **AUTHORS.md**: A list of primary contributors to the `gnubg-nn-pypi` project can be found [here](https://github.com/reayd-falmouth/gnubg-nn-pypi/blob/main/AUTHORS.md).
-- **GNUBG credits.sh**: For a comprehensive list of contributors to the core GNUBG project, please refer to the [credits.sh](https://git.savannah.gnu.org/cgit/gnubg.git/tree/credits.sh) file.
+- **AUTHORS.md**: A list of primary contributors to the `gnubg-nn-pypi` project can be found [here](https://github.com/StonesAndDice/gnubg-nn-pypi/blob/main/AUTHORS.md).
+- **GNU Backgammon (full project) credits.sh**: For a comprehensive list of contributors to the full GNUBG application, please refer to the [credits.sh](https://git.savannah.gnu.org/cgit/gnubg.git/tree/credits.sh) file.
 
 We also thank the broader GNUBG community, including testers, translators, and mailing list participants, for their invaluable support.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,7 +2,7 @@
 API Reference
 =============
 
-This section documents the public Python API provided by the `gnubg-nn-pypi` package. It includes functions for evaluating positions, loading neural nets, and accessing internal neural net state.
+This section documents the public Python API provided by the `gnubg-nn-pypi` package — the GNUBG **neural network evaluation library** (position analysis, cube decisions, rollouts), not the full GNU Backgammon application. It includes functions for evaluating positions, loading neural nets, and accessing internal neural net state.
 
 gnubg.bearoff_id_2_pos(id) -> Tuple[int, int, int, int, int, int]
 -----------------------------------------------------------------

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -2,7 +2,7 @@
 Core Concepts
 =============
 
-This section introduces the key internal concepts and data structures used by the `gnubg-nn-pypi` library, drawn from GNU Backgammon's original architecture.
+This section introduces the key internal concepts and data structures used by the `gnubg-nn-pypi` library. They are drawn from the GNUBG neural network evaluation code (the same logic used by the full GNU Backgammon application, but exposed here as a standalone library).
 
 Position ID
 -----------
@@ -12,9 +12,9 @@ A **Position ID** encodes the entire backgammon board state into a short alphanu
 - Checkers on the bar
 - Checkers borne off
 
-It is base64-encoded and typically 14 characters long. GNUBG uses Position IDs for fast hashing and analysis.
+It is base64-encoded and typically 14 characters long. The GNUBG neural network library uses Position IDs for fast hashing and analysis.
 
-You can convert between Position IDs and board state programmatically using this package's helper tools or GNUBG.
+You can convert between Position IDs and board state programmatically using this package's helper tools.
 
 Match ID
 --------
@@ -30,7 +30,7 @@ Match IDs are crucial for match-aware equity calculations and cubeful evaluation
 Neural Networks
 ---------------
 
-GNU Backgammon uses multiple neural networks to evaluate different game phases:
+The GNUBG neural network library uses multiple neural networks to evaluate different game phases:
 
 - **Contact net** – for standard gameplay with both players interacting
 - **Race net** – for bear-off races
@@ -57,7 +57,7 @@ Types:
 - **One-sided**: equity when only one player has checkers
 - **Two-sided**: both players have checkers
 
-GNU Backgammon can use in-memory or disk-based databases for bearoff. These are loaded at startup and used when positions match supported database shapes.
+The library can use in-memory or disk-based bearoff databases (loaded at startup), used when positions match supported database shapes.
 
 - Supported up to 15 checkers on first 6 points
 - Optional support for **Hypergammon** (3-checker variant)
@@ -65,7 +65,7 @@ GNU Backgammon can use in-memory or disk-based databases for bearoff. These are 
 Evaluation Flow
 ---------------
 
-When evaluating a position, GNUBG (and this package) follows these steps:
+When evaluating a position, the library follows these steps:
 
 1. **Classify** the position: race, crashed, or contact
 2. If in **bearoff DB**, return exact equity
@@ -78,5 +78,5 @@ Additional logic may include:
 - **Noise injection**: Simulate human-like variability
 - **Evaluation depth**: 0-ply, 1-ply, or 2-ply lookahead
 
-These mechanisms allow GNUBG and `gnubg-nn-pypi` to evaluate complex decisions with high precision.
+These mechanisms allow the library to evaluate complex decisions with high precision.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,8 @@
 .. only:: html
 
-   GNUBG Documentation
-   ===========================
+   GNUBG Neural Networks — Documentation
+   ======================================
+   This package is the neural network evaluation library, not the full backgammon application.
 
 .. include:: readme.rst
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1,7 +1,7 @@
 Overview
 ========
 
-**`gnubg-nn-pypi`** is a Python package that provides bindings to the neural network evaluation engine from GNU Backgammon (GNUBG). It allows developers and researchers to evaluate backgammon positions using the same logic and weights that power one of the strongest backgammon AIs in existence.
+**`gnubg-nn-pypi`** is a Python package that provides bindings to the **GNUBG neural network evaluation library** — the same engine used by the full `GNU Backgammon <https://www.gnu.org/software/gnubg/>`_ application for position analysis and cube decisions, but as a standalone library. This package is the neural network library only; it is not the full backgammon application (GUI, match play). It allows developers and researchers to evaluate backgammon positions using the same logic and weights that power one of the strongest backgammon AIs in existence.
 
 This package is ideal for:
 
@@ -17,12 +17,12 @@ Features
 - Load and use official GNUBG weights
 - Generate GNUBG-style 250-feature input vectors from Position IDs
 - Access low-level evaluation scores: win/gammon/backgammon probabilities
-- Python 3 bindings to native C++ GNUBG library
+- Python 3 bindings to the native GNUBG neural network library
 
-Why GNUBG?
-----------
+Why this library?
+-----------------
 
-GNU Backgammon is a free and open-source world-class backgammon engine. Its evaluation pipeline combines neural nets, equity lookups, and rollout simulations. With `gnubg-nn-pypi`, you get the core NN evaluation logic in Python, making it easy to integrate into modern workflows without running the full GUI or CLI.
+GNU Backgammon (GNUBG) is a free and open-source world-class backgammon application. Its evaluation pipeline combines neural nets, equity lookups, and rollout simulations. With `gnubg-nn-pypi`, you get the **neural network evaluation library** from GNUBG in Python — the same logic used by the full application — so you can integrate it into scripts and tools without running the full GUI or CLI.
 
 About Backgammon
 -----------------

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,10 +1,12 @@
-.. image:: https://raw.githubusercontent.com/reayd-falmouth/gnubg-nn-pypi/refs/heads/main/img/gerwinski-gnu-head.png
-   :alt: GNUBG Logo
+.. image:: https://raw.githubusercontent.com/StonesAndDice/gnubg-nn-pypi/refs/heads/main/img/gerwinski-gnu-head.png
+   :alt: GNUBG Neural Networks
    :align: center
    :width: 200px
 
-GNUBG
-=====
+GNUBG Neural Networks
+=====================
+
+This package provides the **neural network evaluation library** from the GNU Backgammon project — not the full backgammon application (GUI, match play). Use it to evaluate positions and cube decisions in Python.
 
 .. image:: https://img.shields.io/pypi/dm/gnubg-nn-pypi.svg?label=PyPI%20downloads
    :target: https://pypi.org/project/gnubg-nn-pypi/
@@ -15,7 +17,7 @@ GNUBG
    :alt: Conda Downloads
 
 .. image:: https://img.shields.io/github/issues/gnubg/gnubg-nn-pypi.svg
-   :target: https://github.com/reayd-falmouth/gnubg-nn-pypi/issues
+   :target: https://github.com/StonesAndDice/gnubg-nn-pypi/issues
    :alt: GitHub Issues
 
 .. image:: https://img.shields.io/badge/license-GPL%20v2-blue.svg
@@ -26,17 +28,17 @@ GNUBG
    :target: https://stackoverflow.com/questions/tagged/gnubg
    :alt: Ask on Stack Overflow
 
-GNUBG NeuralNet Python bindings bring the powerful GNUBG backgammon neural-network engine to Python 3.
+**gnubg-nn** is a library that provides Python bindings to the GNUBG neural-network evaluation engine — the same engine used in the full GNU Backgammon application, but as a standalone library for scripts and tools.
 
 **Project Links**
 
-- **Website:** https://www.gnu.org/software/gnubg/
+- **GNU Backgammon (full application):** https://www.gnu.org/software/gnubg/
 - **Documentation:** http://www.gnubg.org/documentation/doku.php?id=gnu_backgammon_faq
 - **Mailing list:** https://lists.gnu.org/mailman/listinfo/gnubg
-- **Source code:** https://github.com/reayd-falmouth/gnubg-nn-pypi
-- **GNUBG Project:** https://git.savannah.gnu.org/cgit/gnubg/gnubg-nn.git
+- **Source code:** https://github.com/StonesAndDice/gnubg-nn-pypi
+- **GNUBG Neural Networks (gnubg-nn) upstream:** https://git.savannah.gnu.org/cgit/gnubg/gnubg-nn.git
 - **Contributing:** https://savannah.gnu.org/people/
-- **Credits:** https://git.savannah.gnu.org/cgit/gnubg.git/tree/credits.sh
+- **Credits (full GNUBG project):** https://git.savannah.gnu.org/cgit/gnubg.git/tree/credits.sh
 
 **Features**
 
@@ -57,7 +59,7 @@ After installation, run basic unit tests with:
 
 .. code-block:: bash
 
-   python3 -m unittest discover -s gnubg.tests
+   python3 -m unittest discover -s gnubg_nn.tests
 
 AI-Assisted Development
 -----------------------
@@ -78,7 +80,7 @@ These models were used to assist with code generation, documentation drafting, a
 Code of Conduct
 ---------------
 
-Please read the `Code of Conduct <https://github.com/reayd-falmouth/gnubg-nn-pypi/blob/main/CONDUCT.md>`_
+Please read the `Code of Conduct <https://github.com/StonesAndDice/gnubg-nn-pypi/blob/main/CONDUCT.md>`_
 to learn how to interact positively.
 
 Contributing
@@ -95,18 +97,18 @@ Your expertise and enthusiasm are welcome! You can contribute by:
 - Assisting with outreach and onboarding
 - Writing grant proposals or helping with fundraising
 
-For more information, see our `Contributing Guide <https://github.com/reayd-falmouth/gnubg-nn-pypi/blob/main/CONTRIBUTING.md>`_.
+For more information, see our `Contributing Guide <https://github.com/StonesAndDice/gnubg-nn-pypi/blob/main/CONTRIBUTING.md>`_.
 If you’re unsure where to start, open an issue or join the discussion on our mailing list!
 
 Acknowledgments
 ---------------
 
-This project builds upon the extensive work of the GNU Backgammon (GNUBG) community. Specifically the
+This project builds upon the extensive work of the GNU Backgammon (GNUBG) community. The *gnubg-nn* library is the neural network evaluation component; the full backgammon application is maintained separately. Specifically the
 `pygnubg <https://git.savannah.gnu.org/cgit/gnubg/gnubg-nn.git/tree/py>`_ program developed by Joseph Heled.
 
-We express our gratitude to all contributors who have dedicated their time and expertise to the development of GNUBG and its Python bindings.
+We express our gratitude to all contributors who have dedicated their time and expertise to the development of the GNUBG neural network library and its Python bindings.
 
-- **AUTHORS.md**: A list of primary contributors to the `gnubg-nn-pypi` project can be found `here <https://github.com/reayd-falmouth/gnubg-nn-pypi/blob/main/AUTHORS.md>`_.
-- **GNUBG credits.sh**: For a comprehensive list of contributors to the core GNUBG project, see the `credits.sh <https://git.savannah.gnu.org/cgit/gnubg.git/tree/credits.sh>`_ file.
+- **AUTHORS.md**: A list of primary contributors to the `gnubg-nn-pypi` project can be found `here <https://github.com/StonesAndDice/gnubg-nn-pypi/blob/main/AUTHORS.md>`_.
+- **GNU Backgammon (full project) credits.sh**: For a comprehensive list of contributors to the full GNUBG application, see the `credits.sh <https://git.savannah.gnu.org/cgit/gnubg.git/tree/credits.sh>`_ file.
 
 We also thank the broader GNUBG community, including testers, translators, and mailing list participants, for their invaluable support.

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -1,7 +1,7 @@
 References
 ==========
 
-This project builds upon the open-source GNU Backgammon engine, its neural network design, and various community tools. The following resources provide deeper background into the theory and implementation details.
+This package (*gnubg-nn*) is the **neural network evaluation library** from the GNU Backgammon project — not the full backgammon application. It builds upon the open-source GNU Backgammon engine, its neural network design, and various community tools. The following resources provide deeper background into the theory and implementation details.
 
 Official Documentation
 ----------------------
@@ -30,10 +30,10 @@ Neural Networks and AI Concepts
   https://www.bkgm.com/books/Robertie-LearningFromTheMachine.html
 
 - **Backgammon Neural Net Evaluation (GNUBG)**
-  Explained in the official manual and implemented in `eval.c`, `neuralnet.c`, and `getinput.c`.
+  The neural network evaluation code used by both the full GNUBG application and this library. Explained in the official manual and implemented in `eval.c`, `neuralnet.c`, and `getinput.c`.
 
 - **Match Equity Tables and Cube Handling**
-  See the "Match Equity Table" section of the GNUBG Manual and references therein.
+  See the "Match Equity Table" section of the GNU Backgammon manual and references therein.
 
 Python and Project Utilities
 ----------------------------
@@ -59,6 +59,6 @@ Licenses
 
 ---
 
-For bug reports or improvements to the original GNUBG engine, visit:
+For bug reports or improvements to the full GNU Backgammon application, visit:
 https://savannah.gnu.org/projects/gnubg/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "mesonpy"
 
 [project]
 name = "gnubg-nn"
-version = "1.1.0a4"
+version = "1.1.0a5"
 description = "Python3 bindings for GNUBG neural evaluation"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Fixes #40.

**Summary:** README, CONTRIBUTING, and the docs folder now clearly state that this project is **GNUBG Neural Networks** — a *library* for the neural network evaluation engine (position analysis, cube decisions, rollouts), not the full GNU Backgammon application (GUI, match play).

**Changes:**
- **README.md**: Intro clarifies library vs full app; link labels (e.g. "GNU Backgammon (full application)", "GNUBG Neural Networks upstream"); acknowledgments distinguish neural network library vs full project; code example uses `gnubg_nn` consistently.
- **CONTRIBUTING.md**: Clarify neural network library vs full GNUBG project; fix test command to `gnubg_nn.tests`.
- **docs/readme.rst**: Title "GNUBG Neural Networks" + short library description; project links and acknowledgments aligned with README.
- **docs/overview.rst**: Clarify library vs full app; "Why this library?" section.
- **docs/concepts.rst**: Intro and body refer to "the library" / "GNUBG neural network library" where appropriate.
- **docs/references.rst**: Intro states package is the neural network library; reference text for full GNUBG.
- **docs/api.rst**: Intro line clarifying API is for the neural network library.
- **docs/index.rst**: HTML title and one-line clarification.