### PR TITLE
Fix docs and API for 1.1.0a7: package name confusion, legacy aliases, missing exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,38 @@
+## [Unreleased] - 1.1.0a7
+### Changed
+- Fix README Quick Start: corrects function names (`board_from_position_id`, `best_move`, `moves`) and import (`import gnubg_nn`)
+- Add prominent package-name warning in README: `gnubg-nn` not `gnubg`
+- Document that the engine auto-initialises on import; `initnet()` is not required
+- Add Migration / Legacy Names section to API docs mapping old `pygnubg` names to new names
+- Add Package Name warning section to API docs
+- Add deprecated aliases `boardfromkey`, `boardfromid`, `bestmove` for backwards compatibility
+- Expose additional utility functions in `__all__`: `eq2mwc`, `mwc2eq`, `eq2mwc_stderr`, `mwc2eq_stderr`, `luckrating`, `errorrating`, `parsemove`, `movetupletostring`, `full_version`, `short_version`, `git_revision`
+
+## [1.1.0a6] - 2026-04-30
+### Changed
+- Clarify docs: GNUBG Neural Networks is the library, not the full game (fixes #40)
+- Add opening rolls and opening replies tests (fixes #42)
+
+## [1.1.0a4] - 2026-04-01
+### Changed
+- Use PYPI_TEST_TOKEN for TestPyPI (fixes #38)
+- Fix release: drop cp38/cp39 for `requires-python >=3.10`, clean `CIBW_SKIP` (fixes #36)
+- Use correct Twine token per release environment (fixes #34)
+- Rename compiled extension module to `_gnubg_nn` (fixes #31)
+- New module structure with updated packaging
+
+## [1.1.0a2] - 2025-11-01
+### Added
+- Cube Decision Evaluation support (`evaluate_cube_decision`)
+- Windows support for Python versions beyond 3.10 (fixes #8)
+- ReadTheDocs documentation site
+- Dynamic version generation
+
+### Changed
+- Linting fixes across C/C++ source files
+- Improved documentation: updated module comments and project docs
+- Simplified Getting Started section in README and RTD landing page
+
 ## [1.1.0a1] - 2025-05-25
 ### Initial Release
 - First public release of the GNUBG Python extension module.

--- a/README.md
+++ b/README.md
@@ -22,25 +22,38 @@ the same position-analysis and cube-decision routines that power the full GNU Ba
 
 ### Installation
 
+> **Important:** The PyPI package name is `gnubg-nn`, not `gnubg`. Installing `gnubg` will install the unrelated full GNU Backgammon application. The correct command is:
+
 ```bash
 pip install gnubg-nn
-````
+```
+
+Then import it as:
+
+```python
+import gnubg_nn
+```
+
+> **Note:** The engine (neural-network weights, bear-off tables, etc.) initialises automatically on import — you do **not** need to call `initnet()`.
 
 ### Getting Started
 
 ```python
 import gnubg_nn
 
-# Load the engine (weights, bear-off tables, etc. are initialized)
-gnubg_nn.initnet()
+# Convert a 14-char Base64 Position ID to a 2x25 board
+board = gnubg_nn.board_from_position_id("4HPwATDgc/ABMA")
 
-# Convert a position key (20-char A–Z or 14-char Base64) to a board
-board = gnubg_nn.boardfromkey("4HPwATDgc/ABMA")
+# Evaluate win/gammon/backgammon probabilities at 2 plies
+probs = gnubg_nn.probabilities(board, gnubg_nn.p_0plus1)
+win, win_gammon, win_bg, lose_gammon, lose_bg = probs
 
-# Evaluate win/gammon/backgammon probabilities and equity at 4 plies
-win, gamm, bg, equity = gnubg_nn.probabilities(board, 4)
+print(f"Win: {win:.3f}, Gammon: {win_gammon:.3f}, Backgammon: {win_bg:.3f}")
 
-print(f"Win: {win:.3f}, Gammon: {gamm:.3f}, Backgammon: {bg:.3f}, Equity: {equity:.3f}")
+# Find the best move for an opening 6-5 roll
+moves = gnubg_nn.moves(board, 6, 5)
+best = gnubg_nn.best_move(board, 6, 5)
+print(f"Best move key: {best}")
 ```
 
 That’s all you need to get up and running! For detailed API docs, advanced build options, and configuration, see the 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -725,3 +725,63 @@ Available Methods
    gset.seed(42)
    gset.score(3, 2)
    gset.cube('O', 2, False)
+
+Engine Initialisation
+---------------------
+
+The GNUBG neural-network engine (weights, bearoff tables, opening book) is initialised **automatically when you import the package**. You do not need to call any initialisation function:
+
+.. code-block:: python
+
+   import gnubg_nn  # engine ready immediately
+
+If you encounter examples from the original ``pygnubg`` library that call ``initnet()`` or ``gnubg.initnet()``, those calls are not needed and will raise ``AttributeError`` — simply remove them.
+
+Migration from pygnubg / Legacy Names
+--------------------------------------
+
+The ``gnubg-nn`` package modernises function names relative to the original ``pygnubg`` library. If you are porting old code, use the following mapping:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Old name (pygnubg)
+     - New name (gnubg-nn)
+     - Notes
+   * - ``initnet()``
+     - *(not needed)*
+     - Auto-called on import
+   * - ``boardfromkey(key)``
+     - ``board_from_position_key(key)``
+     - 20-char A–Z key
+   * - ``boardfromid(id)``
+     - ``board_from_position_id(id)``
+     - 14-char Base64 Position ID
+   * - ``keyofboard(board)``
+     - ``key_of_board(board)``
+     -
+   * - ``posid(board)`` / ``id(board)``
+     - ``position_id(board)``
+     -
+   * - ``bestmove(...)``
+     - ``best_move(...)``
+     -
+   * - ``pubbestmove(board, d1, d2)``
+     - ``pub_best_move(board, d1, d2)``
+     -
+
+Deprecated aliases (``boardfromkey``, ``boardfromid``, ``bestmove``) are available in ``gnubg_nn`` for backwards compatibility but will be removed in a future release.
+
+Package Name
+------------
+
+.. warning::
+
+   The PyPI package name is ``gnubg-nn``, **not** ``gnubg``. Installing ``gnubg`` installs the unrelated full GNU Backgammon application package, which exposes a different and incompatible API. Always install with::
+
+      pip install gnubg-nn
+
+   and import with::
+
+      import gnubg_nn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "mesonpy"
 
 [project]
 name = "gnubg-nn"
-version = "1.1.0a6"
+version = "1.1.0a7"
 description = "Python3 bindings for GNUBG neural evaluation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gnubgmodule/__init__.py
+++ b/src/gnubgmodule/__init__.py
@@ -9,27 +9,58 @@ if os.name == "nt" and hasattr(os, "add_dll_directory"):
 # Import your compiled extension module
 from ._gnubg_nn import *
 
-# Optional: Expose a namespace
+# Deprecated aliases for backwards compatibility with pygnubg
+boardfromkey = board_from_position_key
+boardfromid = board_from_position_id
+bestmove = best_move
+
 __all__ = [
-    "bearoff_id_2_pos",
-    "bearoff_probabilities",
-    "best_move",
+    # Board conversion
     "board_from_position_id",
     "board_from_position_key",
+    "key_of_board",
+    "position_id",
+    # Move & evaluation
+    "best_move",
+    "moves",
+    "pub_best_move",
+    "pub_eval_score",
+    # Classification
+    "classify",
+    # Probabilities & rollout
+    "probabilities",
+    "rollout",
+    "cubeful_rollout",
+    "one_checker_race",
+    # Cube
+    "evaluate_cube_decision",
+    # Bearoff
+    "bearoff_id_2_pos",
+    "bearoff_probabilities",
+    # Equity / match
+    "equities",
+    # Utility / version
+    "roll",
+    "eq2mwc",
+    "mwc2eq",
+    "eq2mwc_stderr",
+    "mwc2eq_stderr",
+    "luckrating",
+    "errorrating",
+    "parsemove",
+    "movetupletostring",
+    "full_version",
+    "short_version",
+    "git_revision",
+    # Submodules
+    "set",
+    # Position type constants
     "c_bearoff",
     "c_contact",
     "c_crashed",
     "c_over",
     "c_race",
-    "classify",
-    "cubeful_rollout",
-    "equities",
-    "evaluate_cube_decision",
-    "gnubg",
-    "key_of_board",
-    "moves",
-    "one_checker_race",
-    "os",
+    # Ply constants
     "p_0plus1",
     "p_1sbear",
     "p_1srace",
@@ -37,15 +68,13 @@ __all__ = [
     "p_osr",
     "p_prune",
     "p_race",
-    "position_id",
-    "probabilities",
-    "pub_best_move",
-    "pub_eval_score",
+    # Rollout constants
     "ro_auto",
     "ro_bearoff",
     "ro_over",
     "ro_race",
-    "roll",
-    "rollout",
-    "set",
+    # Deprecated aliases (backwards compat with pygnubg)
+    "boardfromkey",
+    "boardfromid",
+    "bestmove",
 ]


### PR DESCRIPTION
## Summary

- **Fix README Quick Start**: corrects function names (`board_from_position_id`, `best_move`, `moves`) and import (`import gnubg_nn`); removes incorrect `initnet()` call
- **Package name confusion warning**: prominent note that the PyPI package is `gnubg-nn` not `gnubg`, and import is `gnubg_nn` not `gnubg`
- **Auto-init documented**: engine initialises on import, no `initnet()` needed — confusing users coming from old pygnubg examples
- **Migration/Legacy Names table** in `docs/api.rst`: maps all old pygnubg names → new gnubg-nn names
- **Deprecated aliases** added to `__init__.py`: `boardfromkey`, `boardfromid`, `bestmove` for backwards compat
- **Missing exports** added to `__all__`: `eq2mwc`, `mwc2eq`, `luckrating`, `errorrating`, `parsemove`, `movetupletostring`, `full_version`, `short_version`, `git_revision`
- **CHANGELOG** filled in for all alpha versions (a1–a6) with unreleased a7 entry
- **Version bump**: `1.1.0a6` → `1.1.0a7`

## Motivation

A user reported installing `gnubg` instead of `gnubg-nn` and getting `AttributeError: module 'gnubg' has no attribute 'initnet'`. Even after installing the correct package, they couldn't find `initnet` or `boardfromkey` in the docs. This PR makes the package name distinction impossible to miss and provides a clear migration path from old pygnubg examples.

## Test plan

- [ ] `pip install gnubg-nn` in a clean venv, run `import gnubg_nn; dir(gnubg_nn)` — confirm new aliases and functions appear
- [ ] Confirm `gnubg_nn.boardfromkey` and `gnubg_nn.boardfromid` work as aliases
- [ ] Run `python3 -m unittest discover -s gnubg_nn.tests` — all pass
- [ ] Confirm README Quick Start code runs without error end-to-end
- [ ] Check ReadTheDocs build renders the Migration and Package Name sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)